### PR TITLE
add build/ to path of phaser.min.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="assets/style.css">
   <script src="//localhost:1337/livereload.js"></script>
   <script src="assets/vendor/jquery/dist/jquery.min.js"></script>
-  <script src="assets/vendor/phaser/phaser.min.js"></script>
+  <script src="assets/vendor/phaser/build/phaser.min.js"></script>
   <script src="build/main.min.js"></script>
 </head>
 <body>


### PR DESCRIPTION
After running `bower install` I noticed that the `phaser.min.js` file is found under `assets/vendor/phaser/build/`. I've updated `index.html` to reflect this change.
